### PR TITLE
Moves window in mindist calculation

### DIFF
--- a/P8/DataConverters/ShapeletHistogramConverter/FeatureExtraction/src/attributes/MinDist.h
+++ b/P8/DataConverters/ShapeletHistogramConverter/FeatureExtraction/src/attributes/MinDist.h
@@ -9,9 +9,11 @@ public:
     [[nodiscard]] inline std::string Name() const final { return "MinDist"; };
 
     [[nodiscard]] static double MinimumDistance(const Series &series, uint offset, const Series &window, std::optional<double> currentMin) {
+        const double yOffset = series[offset];
         double dist = 0;
+
         for (uint i = 1; i < window.size(); i++) {
-            dist += std::abs(series[i + offset] - window.at(i));
+            dist += std::abs(series[i + offset] - (yOffset + window.at(i)));
             if (currentMin.has_value() && dist > currentMin.value())
                 return dist;
         }


### PR DESCRIPTION
Before it compared distance to window, without handling offset
![before](https://user-images.githubusercontent.com/53914190/228895145-81f7c319-04af-40e0-89bc-8c209f29bcb2.png)
Now it handles offset
![after](https://user-images.githubusercontent.com/53914190/228895155-6d602d01-b8cf-48db-84c2-00a278e79cde.png)
